### PR TITLE
perf(job-queue): optimize SQL templates generation logic

### DIFF
--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -30,11 +30,11 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="GitVersion.MsBuild" Version="5.8.1">
+    <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Hangfire.Core" Version="1.7.27" />
+    <PackageReference Include="Hangfire.Core" Version="1.7.32" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
@@ -63,7 +63,7 @@
         <PackageId>Hangfire.PostgreSql</PackageId>
       </PropertyGroup>
       <ItemGroup>
-        <PackageReference Include="Npgsql" Version="6.0.0" />
+        <PackageReference Include="Npgsql" Version="7.0.1" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -225,12 +225,8 @@ namespace Hangfire.PostgreSql
 
         if (!Options.EnableTransactionScopeEnlistment)
         {
-          NpgsqlConnectionStringBuilder connectionStringBuilder;
-#if !USING_NPGSQL_VERSION_5
-          connectionStringBuilder = connection.Settings;
-#else
-          connectionStringBuilder = new(connection.ConnectionString);
-#endif
+          NpgsqlConnectionStringBuilder connectionStringBuilder = new(connection.ConnectionString);
+
           if (connectionStringBuilder.Enlist)
           {
             throw new ArgumentException(

--- a/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
+++ b/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
@@ -18,13 +18,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 


### PR DESCRIPTION
pre-create single instance of SQL strings during class construction instead of on each method invocation

re #278