### PR TITLE
Single listen thread proof of concept.

### DIFF
--- a/src/Hangfire.PostgreSql/NotificationManager.cs
+++ b/src/Hangfire.PostgreSql/NotificationManager.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+using Hangfire.PostgreSql.Utils;
+using Hangfire.Server;
+using Npgsql;
+
+namespace Hangfire.PostgreSql;
+
+#pragma warning disable CS0618
+public class NotificationManager : IBackgroundProcess, IServerComponent
+#pragma warning restore CS0618
+{
+  private const string JobNotificationChannel = "new_job";
+
+  private readonly PostgreSqlStorage _storage;
+
+  public AutoResetEvent NewJob { get; }
+
+  public NotificationManager(PostgreSqlStorage storage)
+  {
+    _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+    NewJob = new AutoResetEvent(false);
+  }
+
+  public void Execute(BackgroundProcessContext context)
+  {
+    Execute(context.StoppingToken);
+  }
+
+  public void Execute(CancellationToken cancellationToken)
+  {
+    if (_storage.Options.EnableLongPolling)
+    {
+      ListenForNotificationsAsync(cancellationToken).Wait(cancellationToken);
+    }
+  }
+
+  public override string ToString()
+  {
+    return "PostgreSQL Notifications Manager";
+  }
+
+  private Task ListenForNotificationsAsync(CancellationToken cancellationToken)
+  {
+    NpgsqlConnection connection = _storage.CreateAndOpenConnection();
+
+    try
+    {
+      if (!connection.SupportsNotifications())
+      {
+        return Task.CompletedTask;
+      }
+
+      // CreateAnOpenConnection can return the same connection over and over if an existing connection
+      //  is passed in the constructor of PostgreSqlStorage. We must use a separate dedicated
+      //  connection to listen for notifications.
+      NpgsqlConnection clonedConnection = connection.CloneWith(connection.ConnectionString);
+
+      return Task.Run(async () => {
+        try
+        {
+          if (clonedConnection.State != ConnectionState.Open)
+          {
+            await clonedConnection.OpenAsync(cancellationToken); // Open so that Dapper doesn't auto-close.
+          }
+
+          while (!cancellationToken.IsCancellationRequested)
+          {
+            await clonedConnection.ExecuteAsync($"LISTEN {JobNotificationChannel}");
+            await clonedConnection.WaitAsync(cancellationToken);
+            NewJob.Set();
+          }
+        }
+        catch (TaskCanceledException)
+        {
+          // Do nothing, cancellation requested so just end.
+        }
+        finally
+        {
+          _storage.ReleaseConnection(clonedConnection);
+        }
+
+      }, cancellationToken);
+
+    }
+    finally
+    {
+      _storage.ReleaseConnection(connection);
+    }
+  }
+
+  public void NotifyNewJob(IDbConnection connection)
+  {
+    if (_storage.Options.EnableLongPolling)
+    {
+      connection.Execute($"NOTIFY {JobNotificationChannel}");
+    }
+  }
+}


### PR DESCRIPTION
-- PROOF OF CONCEPT ONLY, NOT PRODUCTION READY --

I was excited to see the new listen / long polling functionality in the latest release as the polling is a significant load on our database server. On experimenting with it though, it is less effective at reducing query load than I'd hoped.

The current functionality sets up a LISTEN per worker thread, which means that when a new job is posted, every worker wakes up and polls the database at once. This includes when scheduled jobs are created. With a couple of machines, each running multiple worker threads, this adds up quite quickly to a lot of concurrent hits on that locked query. 

This pull request moves the LISTEN loop out to its own background worker so that it only runs once, and wakes a single worker thread when a notification is received (because the AutoResetEvent only wakes one thread). This seems to work quite well with the following caveats:

* This is my first time looking at this code base and I've have a pretty quick hack at it to see what it possible, but it's rough.
* `_newItemInQueueEvent` wakes up extra threads a lot, particular when doing things like creating scheduled jobs. This isn't the end of the world but could be cleaner. I'm not really sure what the intention of this event is though.
* No tests, and only barely "works on my machine" tested.

Is someone able to have a look and see if this is something that might make sense for the library and suggest how to take it forwards please?

Thanks :)