### PR TITLE
Combine two consecutive SQL queries for fetching jobs into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Collaborators:
 Frank Hommers (frankhommers), Vytautas Kasparavičius (vytautask), Žygimantas Arūna (azygis) and Andrew Armstrong (Plasma)
 
 Contributors:
-Burhan Irmikci (barhun), Zachary Sims(zsims), kgamecarter, Stafford Williams (staff0rd), briangweber, Viktor Svyatokha (ahydrax), Christopher Dresel (Dresel), , Vincent Vrijburg, David Roth (davidroth) and Tinyakov.
+Burhan Irmikci (barhun), Zachary Sims(zsims), kgamecarter, Stafford Williams (staff0rd), briangweber, Viktor Svyatokha (ahydrax), Christopher Dresel (Dresel), Vincent Vrijburg, David Roth (davidroth) and Ivan Tiniakov (Tinyakov).
 
 Hangfire.PostgreSql is an Open Source project licensed under the terms of the LGPLv3 license. Please see http://www.gnu.org/licenses/lgpl-3.0.html for license text or COPYING.LESSER file distributed with the source code.
 


### PR DESCRIPTION
From the very first commit, the `PostgreSqlJobQueue` had `fetchConditions` array containing two conditions:
1. Selecting jobs where `fetchedat` = NULL,
2. Selecting old jobs where `fetchedat` is earlier than `InvisibilityTimeout`.

In job-fetching loop this conditions array generated two consecutive SQL queries with no delay between them if the queue is empty. 

So, I combined these two conditions into one query and aligned the results with order clause.

```
WHERE ...
    (""fetchedat"" IS NULL OR ""fetchedat"" < NOW() + INTERVAL '{timeoutSeconds.ToString(CultureInfo.InvariantCulture)} SECONDS')
ORDER BY ""fetchedat"" NULLS FIRST, ...
```

Half the number of SQL queries are needed for fetching 😆.