### PR TITLE
Fixing Enqueued Job Trigger for Multiple Queues

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -37,7 +37,7 @@ namespace Hangfire.PostgreSql
   {
     private const string JobNotificationChannel = "new_job";
 
-    internal static readonly AutoResetEventRegistry _newItemInEvents = new();
+    internal static readonly AutoResetEventRegistry _queueEventRegistry = new();
     private readonly PostgreSqlStorage _storage;
 
     public PostgreSqlJobQueue(PostgreSqlStorage storage)
@@ -151,7 +151,7 @@ namespace Hangfire.PostgreSql
         cancellationToken.WaitHandle,
         SignalDequeue,
         JobQueueNotification,
-      }.Concat(_newItemInEvents.GetWaitHandles(queues)).ToArray();
+      }.Concat(_queueEventRegistry.GetWaitHandles(queues)).ToArray();
 
       do
       {

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -37,7 +37,7 @@ namespace Hangfire.PostgreSql
   {
     private const string JobNotificationChannel = "new_job";
 
-    internal static readonly AutoResetEvent _newItemInQueueEvent = new(true);
+    internal static readonly AutoResetEventRegistry _newItemInEvents = new();
     private readonly PostgreSqlStorage _storage;
 
     public PostgreSqlJobQueue(PostgreSqlStorage storage)
@@ -147,6 +147,12 @@ namespace Hangfire.PostgreSql
         RETURNING ""id"" AS ""Id"", ""jobid"" AS ""JobId"", ""queue"" AS ""Queue"", ""fetchedat"" AS ""FetchedAt"";
       ";
 
+      WaitHandle[] nextFetchIterationWaitHandles = new[] {
+        cancellationToken.WaitHandle,
+        SignalDequeue,
+        JobQueueNotification,
+      }.Concat(_newItemInEvents.GetWaitHandles(queues)).ToArray();
+
       do
       {
         cancellationToken.ThrowIfCancellationRequested();
@@ -181,15 +187,7 @@ namespace Hangfire.PostgreSql
 
         if (fetchedJob == null)
         {
-          WaitHandle.WaitAny(new[] {
-              cancellationToken.WaitHandle,
-              _newItemInQueueEvent,
-              SignalDequeue,
-              JobQueueNotification,
-            },
-            _storage.Options.QueuePollInterval);
-
-          cancellationToken.ThrowIfCancellationRequested();
+          WaitHandle.WaitAny(nextFetchIterationWaitHandles, _storage.Options.QueuePollInterval);
         }
       }
       while (fetchedJob == null);

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -320,20 +320,10 @@ namespace Hangfire.PostgreSql
 
         T result = func(connection, null);
 
-        // TransactionCompleted event is required here, because if this TransactionScope is enlisted within an ambient TransactionScope, the ambient TransactionScope controls when the TransactionScope completes.
-        Transaction.Current.TransactionCompleted += Current_TransactionCompleted;
         transaction.Complete();
 
         return result;
       });
-    }
-
-    private static void Current_TransactionCompleted(object sender, TransactionEventArgs e)
-    {
-      if (e.Transaction.TransactionInformation.Status == TransactionStatus.Committed)
-      {
-        PostgreSqlJobQueue._newItemInQueueEvent.Set();
-      }
     }
 
     internal TransactionScope CreateTransactionScope(IsolationLevel? isolationLevel, TimeSpan? timeout = null)

--- a/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlWriteOnlyTransaction.cs
@@ -59,7 +59,7 @@ namespace Hangfire.PostgreSql
       }, CreateTransactionScope);
       
       // Triggers signals for all queues to which jobs have been added in this transaction
-      _queuesWithAddedJobs.ForEach(PostgreSqlJobQueue._newItemInEvents.Set);
+      _queuesWithAddedJobs.ForEach(PostgreSqlJobQueue._queueEventRegistry.Set);
       _queuesWithAddedJobs.Clear();
     }
 

--- a/src/Hangfire.PostgreSql/Utils/AutoResetEventRegistry.cs
+++ b/src/Hangfire.PostgreSql/Utils/AutoResetEventRegistry.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Hangfire.PostgreSql.Utils
+{
+  /// <summary>
+  /// Represents a registry for managing AutoResetEvent instances using event keys.
+  /// </summary>
+  public class AutoResetEventRegistry
+  {
+    private readonly ConcurrentDictionary<string, AutoResetEvent> _events = new();
+
+    /// <summary>
+    /// Retrieves the wait handles associated with the specified event keys.
+    /// </summary>
+    /// <param name="eventKeys">The event keys.</param>
+    /// <returns>An enumerable of wait handles.</returns>
+    public IEnumerable<WaitHandle> GetWaitHandles(IEnumerable<string> eventKeys)
+    {
+      foreach (string eventKey in eventKeys)
+      {
+        if (_events.TryGetValue(eventKey, out AutoResetEvent handle))
+        {
+          yield return handle;
+        }
+        else
+        {
+          AutoResetEvent newHandle = _events.GetOrAdd(eventKey, new AutoResetEvent(false));
+          yield return newHandle;
+        }
+      }
+    }
+
+    /// <summary>
+    /// Sets the specified event.
+    /// </summary>
+    /// <param name="eventKey">The event key.</param>
+    public void Set(string eventKey)
+    {
+      if (_events.TryGetValue(eventKey, out AutoResetEvent handle))
+      {
+        handle.Set();
+      }
+    }
+  }
+}


### PR DESCRIPTION
There was a significant issue with the new enqueued job trigger that should release waiting in jobs fetching loops. It used only one static `AutoResetEvent` instance for all workers and queues. When this `AutoResetEvent` is released, it only releases one random waiting thread. If it was a thread of a worker with a different queue, the job gets stuck until a new event or the `QueuePollInterval` passes. This situation frequently occurred in my environment.

- Introduced new class `AutoResetEventRegistry` in place of one `AutoResetEvent`. It internally holds several `AutoResetEvent` instances, one for each queue.
- Moved its triggering from `PostgreSqlStorage `to `PostgreSqlWriteOnlyTransaction`, where new jobs are added and committed. The list `_queuesWithAddedJobs` accumulates all queues with added jobs in the transaction, and only those queues fire events after commit. This approach also reduces false positive triggers, as not every transaction contains new jobs.
- Minor: Removed `cancellationToken.ThrowIfCancellationRequested()` after waiting in the fetch loop since it is already executed at the beginning of each iteration.

Concerns:
- I didn't make any changes to the `Dequeue_UpdateCount` method, which is used in case of `UseNativeDatabaseTransactions = false`, because there was originally no signal waiting. I'm not sure if it should be modified.