### PR TITLE
Return new connection string builder instance if connection string changes

### DIFF
--- a/src/Hangfire.PostgreSql/Factories/NpgsqlInstanceConnectionFactoryBase.cs
+++ b/src/Hangfire.PostgreSql/Factories/NpgsqlInstanceConnectionFactoryBase.cs
@@ -8,6 +8,7 @@ public abstract class NpgsqlInstanceConnectionFactoryBase : IConnectionFactory
 {
   private readonly PostgreSqlStorageOptions _options;
   [CanBeNull] private NpgsqlConnectionStringBuilder _connectionStringBuilder;
+  [CanBeNull] private string _connectionString;
 
   protected NpgsqlInstanceConnectionFactoryBase(PostgreSqlStorageOptions options)
   {
@@ -23,13 +24,14 @@ public abstract class NpgsqlInstanceConnectionFactoryBase : IConnectionFactory
 
   protected NpgsqlConnectionStringBuilder SetupConnectionStringBuilder(string connectionString)
   {
-    if (_connectionStringBuilder != null)
+    if (!HasConnectionStringChanged(connectionString))
     {
       return _connectionStringBuilder;
     }
 
     try
     {
+      _connectionString = connectionString;
       NpgsqlConnectionStringBuilder builder = new(connectionString);
 
       // The connection string must not be modified when transaction enlistment is enabled, otherwise it will cause
@@ -46,6 +48,11 @@ public abstract class NpgsqlInstanceConnectionFactoryBase : IConnectionFactory
     {
       throw new ArgumentException($"Connection string is not valid", nameof(connectionString), ex);
     }
+  }
+
+  private bool HasConnectionStringChanged(string connectionString)
+  {
+    return !string.Equals(_connectionString, connectionString, StringComparison.OrdinalIgnoreCase);
   }
 
   /// <inheritdoc />

--- a/src/Hangfire.PostgreSql/Factories/NpgsqlInstanceConnectionFactoryBase.cs
+++ b/src/Hangfire.PostgreSql/Factories/NpgsqlInstanceConnectionFactoryBase.cs
@@ -24,7 +24,7 @@ public abstract class NpgsqlInstanceConnectionFactoryBase : IConnectionFactory
 
   protected NpgsqlConnectionStringBuilder SetupConnectionStringBuilder(string connectionString)
   {
-    if (!HasConnectionStringChanged(connectionString))
+    if (_connectionStringBuilder != null && string.Equals(_connectionString, connectionString, StringComparison.OrdinalIgnoreCase))
     {
       return _connectionStringBuilder;
     }
@@ -48,11 +48,6 @@ public abstract class NpgsqlInstanceConnectionFactoryBase : IConnectionFactory
     {
       throw new ArgumentException($"Connection string is not valid", nameof(connectionString), ex);
     }
-  }
-
-  private bool HasConnectionStringChanged(string connectionString)
-  {
-    return !string.Equals(_connectionString, connectionString, StringComparison.OrdinalIgnoreCase);
   }
 
   /// <inheritdoc />

--- a/src/Hangfire.PostgreSql/PostgreSqlBootstrapperOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlBootstrapperOptions.cs
@@ -42,6 +42,11 @@ public class PostgreSqlBootstrapperOptions
     return UseConnectionFactory(new NpgsqlConnectionFactory(connectionString, _options, connectionSetup));
   }
 
+  public PostgreSqlBootstrapperOptions UseNpgsqlConnection(Func<string> getConnectionString, [CanBeNull] Action<NpgsqlConnection> connectionSetup = null)
+  {
+    return UseConnectionFactory(new NpgsqlConnectionFactory(getConnectionString, _options, connectionSetup));
+  }
+
   /// <summary>
   /// Configures the bootstrapper to use the existing <see cref="NpgsqlConnection"/> for each database action.
   /// </summary>


### PR DESCRIPTION
Fixes issue #343 

Refactor NpgsqlInstanceConnectionFactoryBase to return updated connection string builder instances when connection string changes.