### PR TITLE
#209 - Add Support for Sliding Invisibility Timeouts

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlFetchedJob.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlFetchedJob.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of Hangfire.PostgreSql.
+// This file is part of Hangfire.PostgreSql.
 // Copyright © 2014 Frank Hommers <http://hmm.rs/Hangfire.PostgreSql>.
 // 
 // Hangfire.PostgreSql is free software: you can redistribute it and/or modify
@@ -151,7 +151,10 @@ namespace Hangfire.PostgreSql
           return;
         }
 
-        if (_requeued || _removedFromQueue) return;
+        if (_requeued || _removedFromQueue)
+        {
+          return;
+        }
         
         string updateFetchAtSql = $@"
           UPDATE ""{_storage.Options.SchemaName}"".""jobqueue"" 

--- a/src/Hangfire.PostgreSql/PostgreSqlHeartbeatProcess.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlHeartbeatProcess.cs
@@ -1,0 +1,56 @@
+// This file is part of Hangfire.PostgreSql.
+// Copyright © 2014 Frank Hommers <http://hmm.rs/Hangfire.PostgreSql>.
+// 
+// Hangfire.PostgreSql is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire.PostgreSql  is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire.PostgreSql. If not, see <http://www.gnu.org/licenses/>.
+//
+// This work is based on the work of Sergey Odinokov, author of 
+// Hangfire. <http://hangfire.io/>
+//   
+//    Special thanks goes to him.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Hangfire.Common;
+using Hangfire.Server;
+
+namespace Hangfire.PostgreSql
+{
+#pragma warning disable CS0618
+  internal sealed class PostgreSqlHeartbeatProcess : IServerComponent
+#pragma warning restore CS0618
+  {
+    private readonly ConcurrentDictionary<PostgreSqlFetchedJob, object> _items = new();
+
+    public void Track(PostgreSqlFetchedJob item)
+    {
+      _items.TryAdd(item, null);
+    }
+
+    public void Untrack(PostgreSqlFetchedJob item)
+    {
+      _items.TryRemove(item, out var _);
+    }
+    
+    public void Execute(CancellationToken cancellationToken)
+    {
+      foreach (var item in _items)
+      {
+        item.Key.ExecuteKeepAliveQueryIfRequired();
+      }
+
+      cancellationToken.Wait(TimeSpan.FromSeconds(1));
+    }
+  }
+}

--- a/src/Hangfire.PostgreSql/PostgreSqlHeartbeatProcess.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlHeartbeatProcess.cs
@@ -28,7 +28,7 @@ using Hangfire.Server;
 namespace Hangfire.PostgreSql
 {
 #pragma warning disable CS0618
-  internal sealed class PostgreSqlHeartbeatProcess : IServerComponent
+  internal sealed class PostgreSqlHeartbeatProcess : IServerComponent, IBackgroundProcess
 #pragma warning restore CS0618
   {
     private readonly ConcurrentDictionary<PostgreSqlFetchedJob, object> _items = new();
@@ -51,6 +51,11 @@ namespace Hangfire.PostgreSql
       }
 
       cancellationToken.Wait(TimeSpan.FromSeconds(1));
+    }
+
+    public void Execute(BackgroundProcessContext context)
+    {
+      Execute(context.StoppingToken);
     }
   }
 }

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -260,7 +260,7 @@ namespace Hangfire.PostgreSql
         }
       }
       while (markJobAsFetched == null);
-      
+
       return new PostgreSqlFetchedJob(_storage,
         markJobAsFetched.Id,
         markJobAsFetched.JobId.ToString(CultureInfo.InvariantCulture),

--- a/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlJobQueue.cs
@@ -129,9 +129,7 @@ namespace Hangfire.PostgreSql
         throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
       }
 
-      long timeoutSeconds = _storage.Options.SlidingInvisibilityTimeout.HasValue
-        ? (long)_storage.Options.SlidingInvisibilityTimeout.Value.Negate().TotalSeconds
-        : (long)_storage.Options.InvisibilityTimeout.Negate().TotalSeconds;
+      long timeoutSeconds = (long)_storage.Options.InvisibilityTimeout.Negate().TotalSeconds;
       FetchedJob fetchedJob;
 
       string fetchJobSql = $@"
@@ -193,7 +191,7 @@ namespace Hangfire.PostgreSql
         }
       }
       while (fetchedJob == null);
-      
+
       return new PostgreSqlFetchedJob(_storage,
         fetchedJob.Id,
         fetchedJob.JobId.ToString(CultureInfo.InvariantCulture),
@@ -214,9 +212,7 @@ namespace Hangfire.PostgreSql
         throw new ArgumentException("Queue array must be non-empty.", nameof(queues));
       }
 
-      long timeoutSeconds = _storage.Options.SlidingInvisibilityTimeout.HasValue
-        ? (long)_storage.Options.SlidingInvisibilityTimeout.Value.Negate().TotalSeconds
-        : (long)_storage.Options.InvisibilityTimeout.Negate().TotalSeconds;
+      long timeoutSeconds = (long)_storage.Options.InvisibilityTimeout.Negate().TotalSeconds;
       FetchedJob markJobAsFetched = null;
 
       string jobToFetchSql = $@"

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -101,11 +101,14 @@ namespace Hangfire.PostgreSql
       }
 
       InitializeQueueProviders();
+      HeartbeatProcess = new PostgreSqlHeartbeatProcess();
     }
 
     public PersistentJobQueueProviderCollection QueueProviders { get; internal set; }
 
     internal PostgreSqlStorageOptions Options { get; }
+
+    internal PostgreSqlHeartbeatProcess HeartbeatProcess { get; }
 
     public override IMonitoringApi GetMonitoringApi()
     {
@@ -123,13 +126,15 @@ namespace Hangfire.PostgreSql
     {
       yield return new ExpirationManager(this);
       yield return new CountersAggregator(this, Options.CountersAggregateInterval);
+      yield return HeartbeatProcess;
     }
 
     public override void WriteOptionsToLog(ILog logger)
     {
-      logger.Info("Using the following options for SQL Server job storage:");
+      logger.Info("Using the following options for PostgreSQL job storage:");
       logger.InfoFormat("    Queue poll interval: {0}.", Options.QueuePollInterval);
       logger.InfoFormat("    Invisibility timeout: {0}.", Options.InvisibilityTimeout);
+      logger.InfoFormat("    Sliding invisibility timeout: {0}.", Options.SlidingInvisibilityTimeout);
     }
 
     public override string ToString()

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -126,7 +126,11 @@ namespace Hangfire.PostgreSql
     {
       yield return new ExpirationManager(this);
       yield return new CountersAggregator(this, Options.CountersAggregateInterval);
-      yield return HeartbeatProcess;
+      if (Options.SlidingInvisibilityTimeout.HasValue)
+      {
+        // This is only used to update the sliding invisibility timeouts, so if not enabled then do not use it
+        yield return HeartbeatProcess;
+      }
     }
 
     public override void WriteOptionsToLog(ILog logger)
@@ -134,7 +138,7 @@ namespace Hangfire.PostgreSql
       logger.Info("Using the following options for PostgreSQL job storage:");
       logger.InfoFormat("    Queue poll interval: {0}.", Options.QueuePollInterval);
       logger.InfoFormat("    Invisibility timeout: {0}.", Options.InvisibilityTimeout);
-      logger.InfoFormat("    Sliding invisibility timeout: {0}.", Options.SlidingInvisibilityTimeout);
+      logger.InfoFormat("    Sliding invisibility timeout: {0}.", Options.SlidingInvisibilityTimeout.HasValue ? Options.SlidingInvisibilityTimeout : "disabled");
     }
 
     public override string ToString()

--- a/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorage.cs
@@ -101,7 +101,10 @@ namespace Hangfire.PostgreSql
       }
 
       InitializeQueueProviders();
-      HeartbeatProcess = new PostgreSqlHeartbeatProcess();
+      if (Options.UseSlidingInvisibilityTimeout)
+      {
+        HeartbeatProcess = new PostgreSqlHeartbeatProcess();
+      }
     }
 
     public PersistentJobQueueProviderCollection QueueProviders { get; internal set; }
@@ -126,7 +129,7 @@ namespace Hangfire.PostgreSql
     {
       yield return new ExpirationManager(this);
       yield return new CountersAggregator(this, Options.CountersAggregateInterval);
-      if (Options.SlidingInvisibilityTimeout.HasValue)
+      if (Options.UseSlidingInvisibilityTimeout)
       {
         // This is only used to update the sliding invisibility timeouts, so if not enabled then do not use it
         yield return HeartbeatProcess;
@@ -138,7 +141,7 @@ namespace Hangfire.PostgreSql
       logger.Info("Using the following options for PostgreSQL job storage:");
       logger.InfoFormat("    Queue poll interval: {0}.", Options.QueuePollInterval);
       logger.InfoFormat("    Invisibility timeout: {0}.", Options.InvisibilityTimeout);
-      logger.InfoFormat("    Sliding invisibility timeout: {0}.", Options.SlidingInvisibilityTimeout.HasValue ? Options.SlidingInvisibilityTimeout : "disabled");
+      logger.InfoFormat("    Use sliding invisibility timeout: {0}.", Options.UseSlidingInvisibilityTimeout);
     }
 
     public override string ToString()

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -30,6 +30,7 @@ namespace Hangfire.PostgreSql
     private int _deleteExpiredBatchSize;
     private TimeSpan _distributedLockTimeout;
     private TimeSpan _invisibilityTimeout;
+    private TimeSpan? _slidingInvisibilityTimeout;
     private TimeSpan _jobExpirationCheckInterval;
     private TimeSpan _queuePollInterval;
     private TimeSpan _transactionSerializationTimeout;
@@ -39,6 +40,7 @@ namespace Hangfire.PostgreSql
     {
       QueuePollInterval = TimeSpan.FromSeconds(15);
       InvisibilityTimeout = TimeSpan.FromMinutes(30);
+      SlidingInvisibilityTimeout = null;
       DistributedLockTimeout = TimeSpan.FromMinutes(10);
       TransactionSynchronisationTimeout = TimeSpan.FromMilliseconds(500);
       JobExpirationCheckInterval = TimeSpan.FromHours(1);
@@ -66,6 +68,24 @@ namespace Hangfire.PostgreSql
       set {
         ThrowIfValueIsNotPositive(value, nameof(InvisibilityTimeout));
         _invisibilityTimeout = value;
+      }
+    }
+    
+    /// <summary>
+    /// Maintain a sliding invisibility window using a background timer
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public TimeSpan? SlidingInvisibilityTimeout
+    {
+      get => _slidingInvisibilityTimeout;
+      set
+      {
+        if (value <= TimeSpan.Zero)
+        {
+          throw new ArgumentOutOfRangeException(nameof(value), "Sliding timeout should be greater than zero");
+        }
+
+        _slidingInvisibilityTimeout = value;
       }
     }
 

--- a/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlStorageOptions.cs
@@ -73,8 +73,10 @@ namespace Hangfire.PostgreSql
     
     /// <summary>
     /// Maintain a sliding invisibility window using a background timer
+    /// IMPORTANT: If <see cref="BackgroundJobServerOptions.IsLightweightServer"/> option is used, then sliding invisiblity timeouts will not work
+    /// since the background storage processes are not run (which is used to update the invisibility timeouts) 
     /// </summary>
-    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if timeout value is 0 or negative</exception>
     public TimeSpan? SlidingInvisibilityTimeout
     {
       get => _slidingInvisibilityTimeout;

--- a/src/Hangfire.PostgreSql/Utils/ExceptionTypeHelper.cs
+++ b/src/Hangfire.PostgreSql/Utils/ExceptionTypeHelper.cs
@@ -1,0 +1,39 @@
+// This file is part of Hangfire. Copyright © 2022 Hangfire OÜ.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+// Borrowed from Hangfire
+
+using System;
+
+namespace Hangfire.PostgreSql.Utils
+{
+  internal static class ExceptionTypeHelper
+  {
+#if !NETSTANDARD1_3
+    private static readonly Type StackOverflowType = typeof(StackOverflowException);
+#endif
+    private static readonly Type OutOfMemoryType = typeof(OutOfMemoryException);
+ 
+    internal static bool IsCatchableExceptionType(this Exception e)
+    {
+      var type = e.GetType();
+      return
+#if !NETSTANDARD1_3
+        type != StackOverflowType &&
+#endif
+        type != OutOfMemoryType;
+    }
+  }
+}

--- a/src/Hangfire.PostgreSql/Utils/TimestampHelper.cs
+++ b/src/Hangfire.PostgreSql/Utils/TimestampHelper.cs
@@ -1,0 +1,48 @@
+// This file is part of Hangfire. Copyright © 2022 Hangfire OÜ.
+// 
+// Hangfire is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as 
+// published by the Free Software Foundation, either version 3 
+// of the License, or any later version.
+// 
+// Hangfire is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+// 
+// You should have received a copy of the GNU Lesser General Public 
+// License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
+
+// Borrowed from Hangfire
+
+using System;
+
+namespace Hangfire.PostgreSql.Utils
+{
+  internal static class TimestampHelper
+  {
+    public static long GetTimestamp()
+    {
+#if NETCOREAPP3_0
+            return Environment.TickCount64;
+#else
+      return Environment.TickCount;
+#endif
+    }
+
+    public static TimeSpan Elapsed(long timestamp)
+    {
+      long now = GetTimestamp();
+      return Elapsed(now, timestamp);
+    }
+
+    public static TimeSpan Elapsed(long now, long timestamp)
+    {
+#if NETCOREAPP3_0
+            return TimeSpan.FromMilliseconds(now - timestamp);
+#else
+      return TimeSpan.FromMilliseconds(unchecked((int)now - (int)timestamp));
+#endif
+    }
+  }
+}

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlFetchedJobFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlFetchedJobFacts.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using Dapper;
 using Hangfire.PostgreSql.Tests.Utils;
 using Xunit;
@@ -11,6 +12,7 @@ namespace Hangfire.PostgreSql.Tests
   {
     private const string JobId = "id";
     private const string Queue = "queue";
+    private DateTime _fetchedAt = DateTime.UtcNow; 
 
     private readonly PostgreSqlStorage _storage;
 
@@ -22,7 +24,7 @@ namespace Hangfire.PostgreSql.Tests
     [Fact]
     public void Ctor_ThrowsAnException_WhenStorageIsNull()
     {
-      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new PostgreSqlFetchedJob(null, 1, JobId, Queue));
+      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new PostgreSqlFetchedJob(null, 1, JobId, Queue, _fetchedAt));
 
       Assert.Equal("storage", exception.ParamName);
     }
@@ -30,7 +32,7 @@ namespace Hangfire.PostgreSql.Tests
     [Fact]
     public void Ctor_ThrowsAnException_WhenJobIdIsNull()
     {
-      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new PostgreSqlFetchedJob(_storage, 1, null, Queue));
+      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new PostgreSqlFetchedJob(_storage, 1, null, Queue, _fetchedAt));
 
       Assert.Equal("jobId", exception.ParamName);
     }
@@ -38,19 +40,27 @@ namespace Hangfire.PostgreSql.Tests
     [Fact]
     public void Ctor_ThrowsAnException_WhenQueueIsNull()
     {
-      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new PostgreSqlFetchedJob(_storage, 1, JobId, null));
+      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new PostgreSqlFetchedJob(_storage, 1, JobId, null, _fetchedAt));
 
       Assert.Equal("queue", exception.ParamName);
+    }
+    
+    [Fact]
+    public void Ctor_ThrowsAnException_WhenFetchedAtIsNull()
+    {
+      ArgumentNullException exception = Assert.Throws<ArgumentNullException>(() => new PostgreSqlFetchedJob(_storage, 1, JobId, Queue, null));
+      Assert.Equal("fetchedAt", exception.ParamName);
     }
 
     [Fact]
     public void Ctor_CorrectlySets_AllInstanceProperties()
     {
-      PostgreSqlFetchedJob fetchedJob = new(_storage, 1, JobId, Queue);
+      PostgreSqlFetchedJob fetchedJob = new(_storage, 1, JobId, Queue, _fetchedAt);
 
       Assert.Equal(1, fetchedJob.Id);
       Assert.Equal(JobId, fetchedJob.JobId);
       Assert.Equal(Queue, fetchedJob.Queue);
+      Assert.Equal(_fetchedAt, fetchedJob.FetchedAt);
     }
 
     [Fact]
@@ -58,8 +68,8 @@ namespace Hangfire.PostgreSql.Tests
     public void RemoveFromQueue_ReallyDeletesTheJobFromTheQueue()
     {
       // Arrange
-      long id = CreateJobQueueRecord(_storage, "1", "default");
-      PostgreSqlFetchedJob processingJob = new(_storage, id, "1", "default");
+      long id = CreateJobQueueRecord(_storage, "1", "default", _fetchedAt);
+      PostgreSqlFetchedJob processingJob = new(_storage, id, "1", "default", _fetchedAt);
 
       // Act
       processingJob.RemoveFromQueue();
@@ -75,11 +85,11 @@ namespace Hangfire.PostgreSql.Tests
     public void RemoveFromQueue_DoesNotDelete_UnrelatedJobs()
     {
       // Arrange
-      CreateJobQueueRecord(_storage, "1", "default");
-      CreateJobQueueRecord(_storage, "1", "critical");
-      CreateJobQueueRecord(_storage, "2", "default");
+      CreateJobQueueRecord(_storage, "1", "default", _fetchedAt);
+      CreateJobQueueRecord(_storage, "1", "critical", _fetchedAt);
+      CreateJobQueueRecord(_storage, "2", "default", _fetchedAt);
 
-      PostgreSqlFetchedJob fetchedJob = new PostgreSqlFetchedJob(_storage, 999, "1", "default");
+      PostgreSqlFetchedJob fetchedJob = new PostgreSqlFetchedJob(_storage, 999, "1", "default", _fetchedAt);
 
       // Act
       fetchedJob.RemoveFromQueue();
@@ -89,14 +99,14 @@ namespace Hangfire.PostgreSql.Tests
         connection.QuerySingle<long>($@"SELECT COUNT(*) FROM ""{GetSchemaName()}"".""jobqueue"""));
       Assert.Equal(3, count);
     }
-
+    
     [Fact]
     [CleanDatabase]
     public void Requeue_SetsFetchedAtValueToNull()
     {
       // Arrange
-      long id = CreateJobQueueRecord(_storage, "1", "default");
-      PostgreSqlFetchedJob processingJob = new(_storage, id, "1", "default");
+      long id = CreateJobQueueRecord(_storage, "1", "default", _fetchedAt);
+      PostgreSqlFetchedJob processingJob = new(_storage, id, "1", "default", _fetchedAt);
 
       // Act
       processingJob.Requeue();
@@ -104,16 +114,84 @@ namespace Hangfire.PostgreSql.Tests
       // Assert
       dynamic record = _storage.UseConnection(null, connection =>
         connection.Query($@"SELECT * FROM ""{GetSchemaName()}"".""jobqueue""").Single());
-      Assert.Null(record.FetchedAt);
+      Assert.Null(record.fetchedat);
     }
 
+    [Fact]
+    [CleanDatabase]
+    public void Timer_UpdatesFetchedAtColumn()
+    {
+      _storage.UseConnection(null, connection => {
+        // Arrange
+        var fetchedAt = DateTime.UtcNow.AddMinutes(-5);
+        long id = CreateJobQueueRecord(_storage, "1", "default", fetchedAt);
+        using (var processingJob = new PostgreSqlFetchedJob(_storage, id, "1", "default", fetchedAt))
+        {
+          processingJob.DisposeTimer();
+          Thread.Sleep(TimeSpan.FromSeconds(10));
+          processingJob.ExecuteKeepAliveQueryIfRequired();
+
+          dynamic record = connection.Query($@"SELECT * FROM ""{GetSchemaName()}"".""jobqueue""").Single();
+
+          Assert.NotNull(processingJob.FetchedAt);
+          Assert.Equal<DateTime?>(processingJob.FetchedAt, record.fetchedat);
+          DateTime now = DateTime.UtcNow;
+          Assert.True(now.AddSeconds(-5) < record.fetchedat, (now - record.fetchedat).ToString());
+        }
+      });
+    }
+
+    [Fact]
+    [CleanDatabase]
+    public void RemoveFromQueue_AfterTimer_RemovesJobFromTheQueue()
+    {
+      _storage.UseConnection(null, connection => {
+        // Arrange
+        long id = CreateJobQueueRecord(_storage, "1", "default", _fetchedAt);
+        using (PostgreSqlFetchedJob processingJob = new PostgreSqlFetchedJob(_storage, id, "1", "default", _fetchedAt))
+        {
+          Thread.Sleep(TimeSpan.FromSeconds(10));
+          processingJob.DisposeTimer();
+
+          // Act
+          processingJob.RemoveFromQueue();
+
+          // Assert
+          int count = connection.Query<int>($@"SELECT count(*) FROM ""{GetSchemaName()}"".""jobqueue""").Single();
+          Assert.Equal(0, count);
+        }
+      });
+    }
+
+    [Fact]
+    [CleanDatabase]
+    public void RequeueQueue_AfterTimer_SetsFetchedAtValueToNull()
+    {
+      _storage.UseConnection(null, connection => {
+        // Arrange
+        long id = CreateJobQueueRecord(_storage, "1", "default", _fetchedAt);
+        using (var processingJob = new PostgreSqlFetchedJob(_storage, id, "1", "default", _fetchedAt))
+        {
+          Thread.Sleep(TimeSpan.FromSeconds(10));
+          processingJob.DisposeTimer();
+
+          // Act
+          processingJob.Requeue();
+
+          // Assert
+          dynamic record = connection.Query($@"SELECT * FROM ""{GetSchemaName()}"".""jobqueue""").Single();
+          Assert.Null(record.fetchedat);
+        }
+      });
+    }
+    
     [Fact]
     [CleanDatabase]
     public void Dispose_SetsFetchedAtValueToNull_IfThereWereNoCallsToComplete()
     {
       // Arrange
-      long id = CreateJobQueueRecord(_storage, "1", "default");
-      PostgreSqlFetchedJob processingJob = new(_storage, id, "1", "default");
+      long id = CreateJobQueueRecord(_storage, "1", "default", _fetchedAt);
+      PostgreSqlFetchedJob processingJob = new(_storage, id, "1", "default", _fetchedAt);
 
       // Act
       processingJob.Dispose();
@@ -124,16 +202,17 @@ namespace Hangfire.PostgreSql.Tests
       Assert.Null(record.fetchedat);
     }
 
-    private static long CreateJobQueueRecord(PostgreSqlStorage storage, string jobId, string queue)
+    private static long CreateJobQueueRecord(PostgreSqlStorage storage, string jobId, string queue, DateTime? fetchedAt)
     {
       string arrangeSql = $@"
         INSERT INTO ""{GetSchemaName()}"".""jobqueue"" (""jobid"", ""queue"", ""fetchedat"")
-        VALUES (@Id, @Queue, NOW()) RETURNING ""id""
+        VALUES (@Id, @Queue, @FetchedAt) RETURNING ""id""
       ";
 
       return
-        storage.UseConnection(null, connection => 
-          connection.QuerySingle<long>(arrangeSql, new { Id = Convert.ToInt64(jobId, CultureInfo.InvariantCulture), Queue = queue }));
+        storage.UseConnection(null, connection =>
+          connection.QuerySingle<long>(arrangeSql, 
+            new { Id = Convert.ToInt64(jobId, CultureInfo.InvariantCulture), Queue = queue, FetchedAt = fetchedAt }));
     }
 
     private static string GetSchemaName()

--- a/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
+++ b/tests/Hangfire.PostgreSql.Tests/PostgreSqlJobQueueFacts.cs
@@ -21,6 +21,7 @@ namespace Hangfire.PostgreSql.Tests
     public PostgreSqlJobQueueFacts(PostgreSqlStorageFixture fixture)
     {
       _fixture = fixture;
+      _fixture.SetupOptions(o => o.UseSlidingInvisibilityTimeout = true);
     }
 
     [Fact]
@@ -553,12 +554,7 @@ namespace Hangfire.PostgreSql.Tests
       storage.Options.SchemaName = GetSchemaName();
       storage.Options.UseNativeDatabaseTransactions = useNativeDatabaseTransactions;
       storage.Options.EnableLongPolling = enableLongPolling;
-      if (useSlidingInvisibilityTimeout)
-      {
-        // Set this into the future so tests will fail if using this instead of SlidingInvisibilityTimeout
-        storage.Options.InvisibilityTimeout = TimeSpan.FromDays(30);
-        storage.Options.SlidingInvisibilityTimeout = TimeSpan.FromMinutes(10);
-      }
+      storage.Options.UseSlidingInvisibilityTimeout = useSlidingInvisibilityTimeout;
 
       return new PostgreSqlJobQueue(storage);
     }


### PR DESCRIPTION
This adds the sliding invisibility timeouts functionality (from [#209](https://github.com/hangfire-postgres/Hangfire.PostgreSql/issues/209)) which is ported from SQL Server storage.

(_This also ports a change where when removing from queue or requeuing, it will include the fetchedat in the where clause. See this [commit](https://github.com/HangfireIO/Hangfire/commit/c6f067ef588daf4a22a8306f72e6f0d70b54955f#diff-d1c9a00ca08dbbfa1e03e27d0ff0e7861ccfbd5931e6f8853074f3608dd52095) (Check FetchedAt has expected value to prevent prolonging other's work)._)

As noted in the original ticket, sliding invisibility timeouts is better than invisibility timeouts since as long as the worker instance is running, it will never reassign the job to another worker.  This is much better than setting the invisibility timeout to long timeouts for long running jobs.

The SQL Server storage also implements transaction dequeuing (different to what is implemented here now with the native transaction setting) where it holds an open transaction while the job is running.  This has advantages over using the sliding invisibility timeout (which is why it is the default in SQL Server storage) but it has limitations for very long running jobs since it can hold a transaction for a long period of time which has caused issues with backups on SQL Server (see this ticket [#864](https://github.com/HangfireIO/Hangfire/issues/864)).

Like SQL Server storage, it makes sense to allow both options (and longer term remove the older non-sliding invisibility timeout) rather than implementing just the newer open transaction dequeuing so users can choose the implementation that suits their use case (ie. short running jobs or long running jobs).  

This PR implements sliding invisibility timeouts since this easily extends the current dequeuing functionality and is easily ported across from SQL Server storage.

How this works is it utilizes the existing dequeue functionality but adds a second configurable timeout setting ```SlidingInvisibilityTimeout``` which when set to a value enables using sliding invisibility timeout.  When a job is fetched, it adds the job to the background storage heartbeat process, called from the background server which updates the fetchedat for each job.

This works with both native transactions enabled and disabled.

In detail, given this is basically ported from SQL Server storage it works in basically the same fashion:

1. Dequeue a job and set the fetchedat to now (same query, except using SlidingInvisibilityTimeout value)
2. Return a fetched job which when created adds the job to the PostgreSqlHeartbeatProcess to update
3. The PostgreSqlHeartbeatProcess (an IServerComponent) is called regularly from the background server
4. PostgreSqlHeartbeatProcess calls ExecuteKeepAliveQueryIfRequired method for each running job which updates the fetchedat to now for that job.

ExecuteKeepAliveQueryIfRequired is run 5 times within the sliding invisibility timeout range.

It should be noted that setting the SlidingInvisibilityTimeout to lower than 10 seconds gets very unstable since sometimes it cannot update the fetchedat quick enough before the job is fetched and so duplicate jobs start running.  Ideally this should never be set lower than 1 minute (in my opinion).

The other caveat is that if the worker process has ```IsLightweightServer``` set to true, then sliding invisibility timeouts will not work at all because it relies on the background storage processes running.  There doesn't seem to be any easy way around this without a change to Hangfire.Core.  Hopefully longer term, it will allow storage libraries to either add background processes directly or provide more information to allow them to decide which processes should run when IsLightweightServer is set.