### PR TITLE
Update CI/Pack workflow actions to latest version to ensure they can run on Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
       - name: Restore dependencies
@@ -46,7 +46,7 @@ jobs:
       - name: Test
         run: dotnet test --no-build --verbosity normal --logger "trx;LogFileName=TestResults.trx"
       - name: Test Report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: test-results

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
       - name: Restore dependencies
@@ -26,7 +26,7 @@ jobs:
       - name: Pack
         run: dotnet pack -c Release --no-build --output publish
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: Package
           path: publish/**.nupkg
@@ -53,11 +53,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 6.0.x
       - name: Restore dependencies


### PR DESCRIPTION
Update ci workflow actions to latest versions since older versions are running on node version 16 which is deprecated and will stop being available in Github from mid May.

https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/