### PR TITLE
Change PostgreSqlFetchedJob RemoveFromQueue Method delete sql comparison

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlFetchedJob.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlFetchedJob.cs
@@ -1,4 +1,4 @@
-// This file is part of Hangfire.PostgreSql.
+﻿// This file is part of Hangfire.PostgreSql.
 // Copyright © 2014 Frank Hommers <http://hmm.rs/Hangfire.PostgreSql>.
 // 
 // Hangfire.PostgreSql is free software: you can redistribute it and/or modify
@@ -78,9 +78,9 @@ namespace Hangfire.PostgreSql
         }
         
         _storage.UseConnection(null, connection => connection.Execute($@"
-          DELETE FROM ""{_storage.Options.SchemaName}"".""jobqueue"" WHERE ""id"" = @Id AND ""fetchedat"" = @FetchedAt;
+          DELETE FROM ""{_storage.Options.SchemaName}"".""jobqueue"" WHERE ""id"" = @Id;
         ",
-          new { Id, FetchedAt }));
+          new { Id }));
 
         _removedFromQueue = true;
       }


### PR DESCRIPTION
Runtime : .Net8
Postgres Version : 15.7

PostgresqlFetchedJob RemoveFromQueue method can not handle delete operation for above environments, I dont know whats related it, is is caused for dapper,npgsql or postgresql itself.

However, since this is FetchedJob RemoveFromQueue  and will be triggered by Hangfire itself by execution of job when its completed or applying state null, anyway I think there is no need for fetchedAt column comparison since FetchedJob  already have   jobqueue Id itself.