### PR TITLE
Validate INCLUDE compatibility for index creation in PostgreSQL #390

### DIFF
--- a/src/Hangfire.PostgreSql/Scripts/Install.v23.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v23.sql
@@ -12,9 +12,9 @@ DROP INDEX IF EXISTS ix_hangfire_job_statename_is_not_null;
 DO $$
 BEGIN
     IF current_setting('server_version_num')::int >= 110000 THEN
-        EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) INCLUDE (id) WHERE statename IS NOT NULL';
+        CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) INCLUDE (id) WHERE statename IS NOT NULL;
     ELSE
-        EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) WHERE statename IS NOT NULL';
+		CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) WHERE statename IS NOT NULL;
     END IF;
 END $$;
 

--- a/src/Hangfire.PostgreSql/Scripts/Install.v23.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v23.sql
@@ -1,17 +1,9 @@
 SET search_path = 'hangfire';
 
 DO $$
-DECLARE v_version INTEGER;
 BEGIN
-    IF EXISTS (
-        SELECT 1 FROM information_schema.columns 
-        WHERE table_name = 'schema' AND column_name = 'version'
-    ) THEN
-        SELECT COALESCE(MAX("version")::integer, 0) INTO v_version FROM "schema";
-
-        IF v_version >= 23 THEN
-            RAISE EXCEPTION 'version-already-applied';
-        END IF;
+    IF EXISTS(SELECT 1 FROM "schema" WHERE "version"::integer >= 23) THEN
+        RAISE EXCEPTION 'version-already-applied';
     END IF;
 END $$;
 
@@ -19,12 +11,11 @@ DROP INDEX IF EXISTS ix_hangfire_job_statename_is_not_null;
 
 DO $$
 BEGIN
-    BEGIN
+    IF current_setting('server_version_num')::int >= 110000 THEN
         EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) INCLUDE (id) WHERE statename IS NOT NULL';
-    EXCEPTION
-        WHEN others THEN
-            EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) WHERE statename IS NOT NULL';
-    END;
+    ELSE
+        EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job (statename) WHERE statename IS NOT NULL';
+    END IF;
 END $$;
 
 RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v23.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v23.sql
@@ -1,13 +1,30 @@
-﻿SET search_path = 'hangfire';
+SET search_path = 'hangfire';
 
 DO $$
+DECLARE v_version INTEGER;
 BEGIN
-    IF EXISTS(SELECT 1 FROM "schema" WHERE "version"::integer >= 23) THEN
-        RAISE EXCEPTION 'version-already-applied';
-END IF;
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'schema' AND column_name = 'version'
+    ) THEN
+        SELECT COALESCE(MAX("version")::integer, 0) INTO v_version FROM "schema";
+
+        IF v_version >= 23 THEN
+            RAISE EXCEPTION 'version-already-applied';
+        END IF;
+    END IF;
 END $$;
 
 DROP INDEX IF EXISTS ix_hangfire_job_statename_is_not_null;
-CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) INCLUDE (id) WHERE statename IS NOT NULL;
+
+DO $$
+BEGIN
+    BEGIN
+        EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) INCLUDE (id) WHERE statename IS NOT NULL';
+    EXCEPTION
+        WHEN others THEN
+            EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) WHERE statename IS NOT NULL';
+    END;
+END $$;
 
 RESET search_path;

--- a/src/Hangfire.PostgreSql/Scripts/Install.v23.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v23.sql
@@ -14,7 +14,7 @@ BEGIN
     IF current_setting('server_version_num')::int >= 110000 THEN
         EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) INCLUDE (id) WHERE statename IS NOT NULL';
     ELSE
-        EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job (statename) WHERE statename IS NOT NULL';
+        EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) WHERE statename IS NOT NULL';
     END IF;
 END $$;
 

--- a/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
+++ b/tests/Hangfire.PostgreSql.Tests/Hangfire.PostgreSql.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyTitle>Hangfire.PostgreSql.Tests</AssemblyTitle>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>Hangfire.PostgreSql.Tests</AssemblyName>
     <PackageId>Hangfire.PostgreSql.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>


### PR DESCRIPTION
Runtime : .Net9.0
Postgres Version : postgres:10 alpine

Error:
In PostgreSQL 10, Hangfire.PostgreSql encountered an error during index creation: "syntax error at or near 'INCLUDE'." This happened because the INCLUDE clause is not supported in this version, causing the migration to fail.

Solution: To resolve this, the script now dynamically checks for INCLUDE compatibility. If supported, the index is created with INCLUDE; otherwise, a fallback version without INCLUDE is used. This ensures compatibility with PostgreSQL and later versions.