### PR TITLE
Changed distributed lock exception type

### DIFF
--- a/src/Hangfire.PostgreSql/PostgreSqlDistributedLockException.cs
+++ b/src/Hangfire.PostgreSql/PostgreSqlDistributedLockException.cs
@@ -20,17 +20,14 @@
 //    Special thanks goes to him.
 
 using System;
+using Hangfire.Storage;
 
 namespace Hangfire.PostgreSql
 {
   [Serializable]
-  public class PostgreSqlDistributedLockException : Exception
+  public class PostgreSqlDistributedLockException : DistributedLockTimeoutException
   {
-    public PostgreSqlDistributedLockException(string message) : base(message)
-    {
-    }
-
-    public PostgreSqlDistributedLockException(string message, Exception innerException) : base(message, innerException)
+    public PostgreSqlDistributedLockException(string resource) : base(resource)
     {
     }
   }


### PR DESCRIPTION
Closes #386 

Changed distributed lock exception type so it doesn't bubble up as error level event