### PR TITLE
Azure PostgreSql Azure

### DIFF
--- a/Hangfire.PostgreSql.sln
+++ b/Hangfire.PostgreSql.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\pack.yml = .github\workflows\pack.yml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hangfire.PostgreSql.Azure", "src\Hangfire.PostgreSql.Azure\Hangfire.PostgreSql.Azure.csproj", "{AF77F244-4B8B-4166-88D7-316A92CBABF5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{6044A48D-730B-4D1F-B03A-EB2B458DAF53}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6044A48D-730B-4D1F-B03A-EB2B458DAF53}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6044A48D-730B-4D1F-B03A-EB2B458DAF53}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AF77F244-4B8B-4166-88D7-316A92CBABF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AF77F244-4B8B-4166-88D7-316A92CBABF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AF77F244-4B8B-4166-88D7-316A92CBABF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AF77F244-4B8B-4166-88D7-316A92CBABF5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -41,6 +47,7 @@ Global
 		{3E4DBC41-F38E-4D1C-A6A7-206A132A29D6} = {0D30A51B-814F-474E-93B8-44E9C155255C}
 		{6044A48D-730B-4D1F-B03A-EB2B458DAF53} = {766BE831-F758-46BC-AFD3-BBEEFE0F686F}
 		{AAA78654-9846-4870-A13C-D9DBAF0792C4} = {5CA38188-92EE-453C-A04E-A506DF15A787}
+		{AF77F244-4B8B-4166-88D7-316A92CBABF5} = {0D30A51B-814F-474E-93B8-44E9C155255C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F7E32105-7F61-4127-8517-5E4275B9CABE}

--- a/src/Hangfire.PostgreSql.Azure/Factories/AzureNpgsqlConnectionFactory.cs
+++ b/src/Hangfire.PostgreSql.Azure/Factories/AzureNpgsqlConnectionFactory.cs
@@ -1,0 +1,58 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using Hangfire.PostgreSql.Factories;
+using Hangfire.PostgreSql.Properties;
+using Npgsql;
+
+namespace Hangfire.PostgreSql.Azure.Factories
+{
+  public class AzureNpgsqlConnectionFactory : NpgsqlInstanceConnectionFactoryBase
+  {
+    private readonly NpgsqlDataSource _dataSource;
+
+    /// <summary>
+    /// Instatiates a factory already configured to fetch tokens from azure
+    /// Token is refreshed every 4 hours
+    /// </summary>
+    /// <param name="connectionString"></param>
+    /// <param name="options"></param>
+    /// <param name="dataSourceBuilderSetup">You have here the opportunity to override the datasource builder, including the password provider</param>
+    public AzureNpgsqlConnectionFactory(string connectionString, PostgreSqlStorageOptions options, [CanBeNull] Action<NpgsqlDataSourceBuilder>? dataSourceBuilderSetup = null) : base(options)
+    {
+      NpgsqlDataSourceBuilder dataSourceBuilder = new(connectionString);
+
+      ConfigurePeriodicPasswordProvider(dataSourceBuilder);
+
+      dataSourceBuilderSetup?.Invoke(dataSourceBuilder);
+      _dataSource = dataSourceBuilder.Build()!;
+    }
+
+
+    public override NpgsqlConnection GetOrCreateConnection()
+    {
+      return _dataSource.CreateConnection();
+    }
+
+    private static void ConfigurePeriodicPasswordProvider(NpgsqlDataSourceBuilder dataSourceBuilder)
+    {
+      //Kudos https://mattparker.dev/blog/azure-managed-identity-postgres-aspnetcore
+      dataSourceBuilder.UsePeriodicPasswordProvider(
+          async (connectionStringBuilder, cancellationToken) => {
+            try
+            {
+              DefaultAzureCredentialOptions options = new();
+              DefaultAzureCredential credentials = new(options);
+              AccessToken token = await credentials.GetTokenAsync(new TokenRequestContext(["https://ossrdbms-aad.database.windows.net/.default"]), cancellationToken);
+              return token.Token;
+            }
+            catch
+            {
+              throw;
+            }
+          },
+          TimeSpan.FromHours(4), // successRefreshInterval
+          TimeSpan.FromSeconds(10) // failureRefreshInterval
+      );
+    }
+  }
+}

--- a/src/Hangfire.PostgreSql.Azure/Hangfire.PostgreSql.Azure.csproj
+++ b/src/Hangfire.PostgreSql.Azure/Hangfire.PostgreSql.Azure.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.20.12" />
+    <PackageReference Include="Npgsql" Version="9.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/src/Hangfire.PostgreSql.Azure/PostgreSqlBootstrapperConfigurationExtensions.cs
+++ b/src/Hangfire.PostgreSql.Azure/PostgreSqlBootstrapperConfigurationExtensions.cs
@@ -1,0 +1,25 @@
+﻿using Hangfire.Annotations;
+using Hangfire.PostgreSql.Azure.Factories;
+using Npgsql;
+
+namespace Hangfire.PostgreSql.Azure
+{
+  public static class PostgreSqlBootstrapperConfigurationExtensions
+  {
+    /// <summary>
+    ///   Tells the bootstrapper to use PostgreSQL as a job storage  with the given options
+    /// </summary>
+    /// <param name="configuration">Configuration</param>
+    /// <param name="connectionString">Connection string</param>
+    /// <param name="dataSourceBuilderSetup">You have here the opportunity to override the datasource builder, including the password provider</param>
+    public static IGlobalConfiguration<PostgreSqlStorage> UseAzurePostgreSqlStorage(
+      this IGlobalConfiguration configuration,
+      string connectionString,
+      PostgreSqlStorageOptions options,
+      [CanBeNull] Action<NpgsqlDataSourceBuilder>? dataSourceBuilderSetup = null)
+    {
+      return configuration.UsePostgreSqlStorage(c => c.UseConnectionFactory(new AzureNpgsqlConnectionFactory(connectionString, options, dataSourceBuilderSetup)), options);
+    }
+  }
+
+}


### PR DESCRIPTION
* created a new assembly in order to isolate the requirements for Azure Tokens: Hangfire.PostgreSql.Azure

* implemented a factory so that users can easily plugin