### PR TITLE
Update Dapper package to version 2.1.66

### DIFF
--- a/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
+++ b/src/Hangfire.PostgreSql/Hangfire.PostgreSql.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="GitVersion.MsBuild" Version="5.11.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
**Updated Dapper from 2.0.123 to 2.1.66**

This PR upgrades Dapper to version 2.1.66 from the previously used 2.0.123, which was released back in 2021. The main motivation behind this update is to benefit from bug fixes, performance improvements, and broader .NET compatibility introduced in more recent versions. Keeping libraries up to date also helps ensure long-term maintainability and security.

In addition, version 2.1.x introduces new asynchronous APIs, which offer better support for non-blocking database operations and align more closely with modern .NET best practices for async programming.