### PR TITLE
Use EXECUTE for index creation for compatibility with older PostgreSQL versions.

### DIFF
--- a/src/Hangfire.PostgreSql/Scripts/Install.v23.sql
+++ b/src/Hangfire.PostgreSql/Scripts/Install.v23.sql
@@ -12,7 +12,7 @@ DROP INDEX IF EXISTS ix_hangfire_job_statename_is_not_null;
 DO $$
 BEGIN
     IF current_setting('server_version_num')::int >= 110000 THEN
-        CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) INCLUDE (id) WHERE statename IS NOT NULL;
+        EXECUTE 'CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) INCLUDE (id) WHERE statename IS NOT NULL';
     ELSE
 		CREATE INDEX ix_hangfire_job_statename_is_not_null ON job USING btree(statename) WHERE statename IS NOT NULL;
     END IF;


### PR DESCRIPTION
Fix for: https://github.com/hangfire-postgres/Hangfire.PostgreSql/issues/404